### PR TITLE
Add exit code for relabelling failure

### DIFF
--- a/src/aiida_quantumespresso_hp/calculations/functions/structure_relabel_kinds.py
+++ b/src/aiida_quantumespresso_hp/calculations/functions/structure_relabel_kinds.py
@@ -64,7 +64,10 @@ def structure_relabel_kinds(
                 new_magnetization[kind_name] = old_magnetization[site['kind']]
 
         site = sites[index]
-        relabeled.append_atom(position=site.position, symbols=symbol, name=kind_name)
+        try:
+            relabeled.append_atom(position=site.position, symbols=symbol, name=kind_name)
+        except ValueError as exc:
+            raise ValueError('cannot distinguish kinds with the given Hubbard input configuration') from exc
 
     # Now add the non-Hubbard sites
     for site in sites[len(relabeled.sites):]:

--- a/src/aiida_quantumespresso_hp/workflows/hubbard.py
+++ b/src/aiida_quantumespresso_hp/workflows/hubbard.py
@@ -171,6 +171,9 @@ class SelfConsistentHubbardWorkChain(WorkChain, ProtocolMixin):
 
         spec.exit_code(330, 'ERROR_FAILED_TO_DETERMINE_PSEUDO_POTENTIAL',
             message='Failed to determine the correct pseudo potential after the structure changed its kind names.')
+        spec.exit_code(340, 'ERROR_RELABELLING_KINDS',
+            message='Failed to determine the kind names during the relabelling.')
+
         spec.exit_code(401, 'ERROR_SUB_PROCESS_FAILED_RECON',
             message='The reconnaissance PwBaseWorkChain sub process failed')
         spec.exit_code(402, 'ERROR_SUB_PROCESS_FAILED_RELAX',
@@ -428,9 +431,13 @@ class SelfConsistentHubbardWorkChain(WorkChain, ProtocolMixin):
         if not is_intersite_hubbard(workchain.outputs.hubbard_structure.hubbard):
             for site in workchain.outputs.hubbard.dict.sites:
                 if not site['type'] == site['new_type']:
-                    result = structure_relabel_kinds(
-                        self.ctx.current_hubbard_structure, workchain.outputs.hubbard, self.ctx.current_magnetic_moments
-                    )
+                    try:
+                        result = structure_relabel_kinds(
+                            self.ctx.current_hubbard_structure, workchain.outputs.hubbard,
+                            self.ctx.current_magnetic_moments
+                        )
+                    except ValueError:
+                        return self.exit_codes.ERROR_RELABELLING_KINDS
                     self.ctx.current_hubbard_structure = result['hubbard_structure']
                     if self.ctx.current_magnetic_moments is not None:
                         self.ctx.current_magnetic_moments = result['starting_magnetization']


### PR DESCRIPTION
Fixes #66

The relabel function might not work if the spin configuration changes and the kinds cannot be determined uniquely by the parsed configuration from the hp.x post-processing. For this reason, we catch the error and exit smoothly with a new exit code if this would happen.