### PR TITLE
Fix the convergence check in self-consistent workflow

### DIFF
--- a/src/aiida_quantumespresso_hp/workflows/hubbard.py
+++ b/src/aiida_quantumespresso_hp/workflows/hubbard.py
@@ -634,7 +634,7 @@ class SelfConsistentHubbardWorkChain(WorkChain, ProtocolMixin):
         new = np.array(new_onsites, dtype='object')
         diff = np.abs(old[:, 4] - new[:, 4])
 
-        if (diff > self.inputs.tolerance_onsite).all():
+        if (diff > self.inputs.tolerance_onsite).any():
             check_onsites = False
             self.report(f'Hubbard onsites parameters are not converged. Max difference is {diff.max()}.')
 
@@ -644,7 +644,7 @@ class SelfConsistentHubbardWorkChain(WorkChain, ProtocolMixin):
             new = np.array(new_intersites, dtype='object')
             diff = np.abs(old[:, 4] - new[:, 4])
 
-            if (diff > self.inputs.tolerance_intersite).all():
+            if (diff > self.inputs.tolerance_intersite).any():
                 check_onsites = False
                 self.report(f'Hubbard intersites parameters are not converged. Max difference is {diff.max()}.')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -377,7 +377,7 @@ def generate_structure():
 def generate_hubbard_structure(generate_structure):
     """Return a `HubbardStructureData` representing bulk silicon."""
 
-    def _generate_hubbard_structure(only_u=False, u_value=1e-5, v_value=1e-5):
+    def _generate_hubbard_structure(only_u=False, u_value=1e-5, v_value=1e-5, u_o_value=1e-5):
         """Return a `StructureData` representing bulk silicon."""
         from aiida_quantumespresso.data.hubbard_structure import HubbardStructureData
 
@@ -386,9 +386,12 @@ def generate_hubbard_structure(generate_structure):
 
         if only_u:
             hubbard_structure.initialize_onsites_hubbard('Co', '3d', u_value)
+            hubbard_structure.initialize_onsites_hubbard('O', '2p', u_o_value)
         else:
             hubbard_structure.initialize_onsites_hubbard('Co', '3d', u_value)
+            hubbard_structure.initialize_onsites_hubbard('O', '2p', u_o_value)
             hubbard_structure.initialize_intersites_hubbard('Co', '3d', 'O', '2p', v_value)
+            hubbard_structure.initialize_intersites_hubbard('O', '2p', 'Co', '3d', u_o_value)
 
         return hubbard_structure
 


### PR DESCRIPTION
The convergence check on parameters had a bug in the logic. That logic would work for 1 Hubbard atom only, and that's the reason why this passed unseen in the tests. The fix is rather simple, and the new tests are tested again a case which made the old tests to make.