### PR TITLE
CI: add integration test running main workflow

### DIFF
--- a/.github/config/code-hp.yaml
+++ b/.github/config/code-hp.yaml
@@ -5,5 +5,3 @@ default_calc_job_plugin: quantumespresso.hp
 computer: localhost
 prepend_text: 'export OMP_NUM_THREADS=1'
 append_text: ' '
-
-

--- a/.github/config/code-hp.yaml
+++ b/.github/config/code-hp.yaml
@@ -1,0 +1,9 @@
+---
+label: hp
+description: Quantum ESPRESSO hp.x
+default_calc_job_plugin: quantumespresso.hp
+computer: localhost
+prepend_text: 'export OMP_NUM_THREADS=1'
+append_text: ' '
+
+

--- a/.github/config/code-pw.yaml
+++ b/.github/config/code-pw.yaml
@@ -5,5 +5,3 @@ default_calc_job_plugin: quantumespresso.pw
 computer: localhost
 prepend_text: 'export OMP_NUM_THREADS=1'
 append_text: ' '
-
-

--- a/.github/config/code-pw.yaml
+++ b/.github/config/code-pw.yaml
@@ -1,0 +1,9 @@
+---
+label: pw
+description: Quantum ESPRESSO pw.x
+default_calc_job_plugin: quantumespresso.pw
+computer: localhost
+prepend_text: 'export OMP_NUM_THREADS=1'
+append_text: ' '
+
+

--- a/.github/config/localhost-config.yaml
+++ b/.github/config/localhost-config.yaml
@@ -1,4 +1,3 @@
 ---
 use_login_shell: true
 safe_interval: 0
-

--- a/.github/config/localhost-config.yaml
+++ b/.github/config/localhost-config.yaml
@@ -1,0 +1,4 @@
+---
+use_login_shell: true
+safe_interval: 0
+

--- a/.github/config/localhost-setup.yaml
+++ b/.github/config/localhost-setup.yaml
@@ -1,0 +1,13 @@
+---
+label: localhost
+description: localhost
+hostname: localhost
+transport: core.local
+scheduler: core.direct
+shebang: '#!/usr/bin/env bash'
+work_dir: /tmp
+mpirun_command: ' '
+mpiprocs_per_machine: 1
+prepend_text: ' '
+append_text: ' '
+

--- a/.github/config/localhost-setup.yaml
+++ b/.github/config/localhost-setup.yaml
@@ -10,4 +10,3 @@ mpirun_command: ' '
 mpiprocs_per_machine: 1
 prepend_text: ' '
 append_text: ' '
-

--- a/.github/config/profile.yaml
+++ b/.github/config/profile.yaml
@@ -1,0 +1,13 @@
+---
+profile: test
+email: aiida@localhost
+first_name: Giuseppe
+last_name: Verdi
+institution: Khedivial
+repository: /tmp/
+db_host: 127.0.0.1
+db_port: 5432
+db_name: postgres
+db_username: postgres
+db_password: postgres
+

--- a/.github/config/profile.yaml
+++ b/.github/config/profile.yaml
@@ -10,4 +10,3 @@ db_port: 5432
 db_name: postgres
 db_username: postgres
 db_password: postgres
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
                     -   5672:5672
 
             steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v4
 
             -   name: Cache Python dependencies
                 uses: actions/cache@v1
@@ -111,10 +111,10 @@ jobs:
                         pip-${{ matrix.python-version }}-tests
 
             -   name: Setup Conda
-                uses: s-weigand/setup-conda@v1
+                uses: conda-incubator/setup-miniconda@v3
                 with:
                     python-version: ${{ matrix.python-version }}
-                    conda-channels: conda-forge
+                    channels: conda-forge
 
             -   name: Set up Quantum ESPRESSO
                 run: conda install -y qe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
             strategy:
                 matrix:
-                    python-version: ['3.9']
+                    python-version: ['3.9', '3.11']
 
             defaults:
                 run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         -   name: Set up Python
             uses: actions/setup-python@v2
             with:
-                python-version: '3.8'
+                python-version: '3.9'
 
         -   name: Install python dependencies
             run: pip install -e .[pre-commit,tests]
@@ -40,7 +40,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.8', '3.9']
+                python-version: ['3.9']
 
         services:
             rabbitmq:
@@ -75,3 +75,70 @@ jobs:
 
         -   name: Run pytest
             run: pytest -sv tests
+
+    integration:
+
+            runs-on: ubuntu-latest
+
+            strategy:
+                matrix:
+                    python-version: ['3.9']
+
+            services:
+                postgres:
+                    image: postgres:12
+                    env:
+                        POSTGRES_HOST: 127.0.0.1
+                        POSTGRES_USER: postgres
+                        POSTGRES_PASSWORD: postgres
+                        POSTGRES_DB: postgres
+                    ports:
+                    -   5432:5432
+                rabbitmq:
+                    image: rabbitmq:latest
+                    ports:
+                    -   5672:5672
+
+            steps:
+            -   uses: actions/checkout@v2
+
+            -   name: Cache Python dependencies
+                uses: actions/cache@v1
+                with:
+                    path: ~/.cache/pip
+                    key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
+                    restore-keys:
+                        pip-${{ matrix.python-version }}-tests
+
+            -   name: Setup Conda
+                uses: s-weigand/setup-conda@v1
+                with:
+                    python-version: ${{ matrix.python-version }}
+                    conda-channels: conda-forge
+
+            -   name: Set up Quantum ESPRESSO
+                run: conda install -y qe
+
+            -   name: Install Python dependencies
+                run: pip install -e .[tests]
+
+            -   name: Create AiiDA profile
+                run: verdi setup -n --config .github/config/profile.yaml
+
+            -   name: Setup localhost
+                run: verdi computer setup -n --config .github/config/localhost-setup.yaml
+
+            -   name: Configure localhost
+                run: verdi computer configure core.local localhost -n --config .github/config/localhost-config.yaml
+
+            -   name: Setup `pw.x`
+                run: verdi code create core.code.installed -n --config .github/config/code-pw.yaml --filepath-executable $(which pw.x)
+
+            -   name: Setup `hp.x`
+                run: verdi code create core.code.installed -n --config .github/config/code-hp.yaml --filepath-executable $(which hp.x)
+
+            -   name: Setup SSSP
+                run: aiida-pseudo install sssp -v 1.3 -x PBEsol -p efficiency
+
+            -   name: Run example scripts
+                run: pytest -sv examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
                 matrix:
                     python-version: ['3.9']
 
+            defaults:
+                run:
+                    shell: bash -l {0}
+
             services:
                 postgres:
                     image: postgres:12
@@ -115,9 +119,10 @@ jobs:
                 with:
                     python-version: ${{ matrix.python-version }}
                     channels: conda-forge
+                    auto-activate-base: true
 
             -   name: Set up Quantum ESPRESSO
-                run: conda install -y qe
+                run: conda install -y qe pip
 
             -   name: Install Python dependencies
                 run: pip install -e .[tests]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,16 +15,15 @@
 import pathlib
 import time
 
-# Load the dummy profile even if we are running locally, this way the documentation will succeed even if the current
-# default profile of the AiiDA installation does not use a Django backend.
-from aiida.manage.configuration import load_documentation_profile
+from aiida.manage.configuration import Profile, load_profile
+
+import aiida_quantumespresso_hp
+
+load_profile(Profile('docs', {'process_control': {}, 'storage': {}}))
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-import aiida_quantumespresso_hp
-
-load_documentation_profile()
 
 # -- Project information -----------------------------------------------------
 

--- a/examples/example_sc_hubbard.py
+++ b/examples/example_sc_hubbard.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env runaiida
 # -*- coding: utf-8 -*-
+"""Test actual run of self-consistent Hubbard workchain."""
 from aiida import load_profile
 from aiida.engine import run
 from aiida.orm import StructureData, load_code
-from ase.build import bulk
-
-from aiida_quantumespresso.common.types import SpinType, RelaxType, ElectronicType
+from aiida_quantumespresso.common.types import ElectronicType, SpinType  # RelaxType
 from aiida_quantumespresso.data.hubbard_structure import HubbardStructureData
+
 from aiida_quantumespresso_hp.workflows.hubbard import SelfConsistentHubbardWorkChain
 
 load_profile()
@@ -24,11 +24,11 @@ def test_self_consistent_hubbard():
         structure.append_atom(position=position, symbols=symbol)
 
     hubbard_structure = HubbardStructureData.from_structure(structure)
-    hubbard_structure.initialize_onsites_hubbard('Co','3d',5.0)
+    hubbard_structure.initialize_onsites_hubbard('Co', '3d', 5.0)
 
     pw_code = load_code('pw@localhost')
     hp_code = load_code('hp@localhost')
-    
+
     kwargs = {
         'electronic_type': ElectronicType.INSULATOR,
         # 'relax_type': RelaxType.POSITIONS, # uncomment this to relax positions only, and related lines below
@@ -65,16 +65,15 @@ def test_self_consistent_hubbard():
         },
         **kwargs
     )
-    builder.pop('relax') # comment this to also relax
+    builder.pop('relax')  # comment this to also relax
 
-    results, node = run.get_node(builder)
+    _, node = run.get_node(builder)
     assert node.is_finished_ok, f'{node} failed: [{node.exit_status}] {node.exit_message}'
-    
+
     u_sc = node.outputs.hubbard_structure.hubbard.parameters[0].value
-    u_ref = 8.1 # eV
-    assert abs(u_sc-u_ref) < 0.5
+    u_ref = 8.1  # eV
+    assert abs(u_sc - u_ref) < 0.5
 
 
 if __name__ == '__main__':
-    """Run script."""
     test_self_consistent_hubbard()

--- a/examples/example_sc_hubbard.py
+++ b/examples/example_sc_hubbard.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env runaiida
+# -*- coding: utf-8 -*-
+from aiida import load_profile
+from aiida.engine import run
+from aiida.orm import StructureData, load_code
+from ase.build import bulk
+
+from aiida_quantumespresso.common.types import SpinType, RelaxType, ElectronicType
+from aiida_quantumespresso.data.hubbard_structure import HubbardStructureData
+from aiida_quantumespresso_hp.workflows.hubbard import SelfConsistentHubbardWorkChain
+
+load_profile()
+
+
+def test_self_consistent_hubbard():
+    """Run a simple example of the self-consistent Hubbard workflow."""
+    # LiCoO2 structure used in QuantumESPRESSO HP examples.
+    a, b, c, d = 1.40803, 0.81293, 4.68453, 1.62585
+    cell = [[a, -b, c], [0.0, d, c], [-a, -b, c]]
+    positions = [[0, 0, 0], [0, 0, 3.6608], [0, 0, 10.392], [0, 0, 7.0268]]
+    symbols = ['Co', 'O', 'O', 'Li']
+    structure = StructureData(cell=cell)
+    for position, symbol in zip(positions, symbols):
+        structure.append_atom(position=position, symbols=symbol)
+
+    hubbard_structure = HubbardStructureData.from_structure(structure)
+    hubbard_structure.initialize_onsites_hubbard('Co','3d',5.0)
+
+    pw_code = load_code('pw@localhost')
+    hp_code = load_code('hp@localhost')
+    
+    kwargs = {
+        'electronic_type': ElectronicType.INSULATOR,
+        # 'relax_type': RelaxType.POSITIONS, # uncomment this to relax positions only, and related lines below
+        'spin_type': SpinType.NONE,
+    }
+
+    builder = SelfConsistentHubbardWorkChain.get_builder_from_protocol(
+        pw_code=pw_code,
+        hp_code=hp_code,
+        hubbard_structure=hubbard_structure,
+        protocol='fast',
+        overrides={ # this can be more conveniently moved on file as .yaml file
+            # 'relax':{
+            #     'base':{
+            #         'kpoints_distance': 100.0, # so high that it gives 1x1x1
+            #     },
+            # },
+            'scf':{
+                'kpoints_distance': 100.0, # so high that it gives 1x1x1
+                'pw':{
+                    'parameters':{
+                        'SYSTEM':{
+                            'ecutwfc': 30.0,
+                            'ecutrho': 30.0 * 8,
+                        },
+                    },
+                },
+            },
+            'hubbard':{
+                'parallelize_atoms': True,
+                'parallelize_qpoints': False,
+                'qpoints_distance': 100.0, # so high that it gives 1x1x1
+            },
+        },
+        **kwargs
+    )
+    builder.pop('relax') # comment this to also relax
+
+    results, node = run.get_node(builder)
+    assert node.is_finished_ok, f'{node} failed: [{node.exit_status}] {node.exit_message}'
+    
+    u_sc = node.outputs.hubbard_structure.hubbard.parameters[0].value
+    u_ref = 8.1 # eV
+    assert abs(u_sc-u_ref) < 0.5
+
+
+if __name__ == '__main__':
+    """Run script."""
+    test_self_consistent_hubbard()

--- a/examples/example_sc_hubbard.py
+++ b/examples/example_sc_hubbard.py
@@ -59,7 +59,7 @@ def test_self_consistent_hubbard():
             },
             'hubbard':{
                 'parallelize_atoms': True,
-                'parallelize_qpoints': False,
+                'parallelize_qpoints': True,
                 'qpoints_distance': 100.0, # so high that it gives 1x1x1
             },
         },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ docs = [
 ]
 pre-commit = [
     'pre-commit~=2.17',
-    'pylint~=2.12.2',
+    'pylint~=2.15.10',
     'pylint-aiida~=0.1.1',
     'toml'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
 keywords = ['aiida', 'workflows']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida-core~=2.2',
-    'aiida-quantumespresso~=4.3',
+    'aiida-core>=2.4',
+    'aiida-quantumespresso>=4.8',
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 keywords = ['aiida', 'workflows']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida-core>=2.4',
+    'aiida-core>=2.2.2,<=2.5',
     'aiida-quantumespresso>=4.8',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,10 +123,15 @@ disable = [
 ]
 
 [tool.pytest.ini_options]
+# Configuration for [pytest](https://docs.pytest.org)
+python_files = "test_*.py example_*.py"
 filterwarnings = [
-    'ignore:Creating AiiDA configuration folder.*:UserWarning'
+    "ignore::DeprecationWarning:aiida:",
+    "ignore:Creating AiiDA configuration folder:",
+    "ignore::DeprecationWarning:plumpy:",
+    "ignore::DeprecationWarning:yaml:",
 ]
-testpaths = 'tests'
+# testpaths = 'tests'
 
 [tool.yapf]
 align_closing_bracket_with_visual_indent = true

--- a/src/aiida_quantumespresso_hp/calculations/hp.py
+++ b/src/aiida_quantumespresso_hp/calculations/hp.py
@@ -211,17 +211,17 @@ class HpCalculation(CalcJob):
         return f'{cls.prefix}.Hubbard_parameters.dat'
 
     @classproperty
-    def filename_input_hubbard_parameters(cls):  # pylint: disable=no-self-argument,invalid-name, no-self-use
+    def filename_input_hubbard_parameters(cls):  # pylint: disable=no-self-argument,invalid-name
         """Return the relative input filename for Hubbard parameters, for QuantumESPRESSO version below 7.1."""
         return 'parameters.in'
 
     @classproperty
-    def filename_output_hubbard_dat(cls):  # pylint: disable=no-self-argument,invalid-name, no-self-use
+    def filename_output_hubbard_dat(cls):  # pylint: disable=no-self-argument,invalid-name
         """Return the relative input filename for generalised Hubbard parameters, for QuantumESPRESSO v.7.2 onwards."""
         return 'HUBBARD.dat'
 
     @classproperty
-    def dirname_output(cls):  # pylint: disable=no-self-argument, no-self-use
+    def dirname_output(cls):  # pylint: disable=no-self-argument
         """Return the relative directory name that contains raw output data."""
         return 'out'
 


### PR DESCRIPTION
Add integration test on real run of the main self-consistent workflow to keep track of possible issues arising from both aiida-core, or related python packages, and Quantum ESPRESSO itself, which might apply sudden changes that we cannot account for in the unit testing suite.